### PR TITLE
Updated gateway service port to 80 in ingress backend

### DIFF
--- a/kasten-ingress.yaml
+++ b/kasten-ingress.yaml
@@ -14,4 +14,4 @@ spec:
               service:
                 name: gateway
                 port:
-                  number: 8000
+                  number: 80


### PR DESCRIPTION
### Problem Description:
k10 Dashboard is not accessible via Ingress since the backend port in ingress not correct.

### Summary:
This PR updates the backend port specified in the Ingress resource for the gateway . The backend service's port was updated, and this change reflects the new port configuration to ensure that traffic is routed correctly to the service for kasten dashboard.

### Changes:
Updated the ingress backend service port to 80 instead of 8000

### Testing:
Verified that the Ingress resource is correctly pointing to the updated service port.
